### PR TITLE
Fix CI formatting and isort/black steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,13 @@ jobs:
         pip install -r requirements.txt -r requirements-dev.txt
 
     - name: Run black
-      run: black .
+      run: black --check .
 
     - name: Run flake8
       run: flake8 --max-line-length=100 .
 
     - name: Run isort
-      run: isort .
+      run: isort --check .
 
     - name: Run mypy
       run: mypy --config-file=mypy.ini .


### PR DESCRIPTION
The black and isort steps were formatting the code, which does not make sense in CI instead of checking if it was formatted correctly. Also fixes some formatting in the CI file itself.

If this PR is merged, there will be CI failures because of formatting, but I will create another PR to fix that.