### PR TITLE
Support molecules without structure data in exctract_structure_data

### DIFF
--- a/fame3r/compute_descriptors.py
+++ b/fame3r/compute_descriptors.py
@@ -70,7 +70,7 @@ class MoleculeProcessor:
     @staticmethod
     def extract_structure_data(mol: Chem.Molecule) -> dict:
         """Extract structure data from a molecule."""
-        struct_data = Chem.getStructureData(mol)
+        struct_data = Chem.getStructureData(mol) if Chem.hasStructureData(mol) else []
         data_dict = {}
 
         for entry in struct_data:


### PR DESCRIPTION
Previously passing a molecule without structure data to this routine
would cause an exception, now it just returns empty structur data.