### PR TITLE
Update and improve type hints

### DIFF
--- a/fame3r/compute_descriptors.py
+++ b/fame3r/compute_descriptors.py
@@ -5,7 +5,6 @@ import os
 import sys
 import warnings
 from pathlib import Path
-from typing import List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -89,7 +88,7 @@ class DescriptorGenerator:
 
     def generate_descriptors(
         self, ctr_atom: Chem.Atom, molgraph: Chem.MolecularGraph
-    ) -> tuple:
+    ) -> tuple[list[str], np.ndarray]:
         """Generate descriptors for a given atom in a molecule.
 
         Args:
@@ -231,7 +230,7 @@ class FAMEDescriptors:
 
     def _process_molecule(
         self, mol: Chem.Molecule, has_soms: bool
-    ) -> Tuple[Tuple, dict]:
+    ) -> tuple[tuple, dict]:
         """Process a molecule and generate descriptors for each atom.
 
         Args:
@@ -264,7 +263,7 @@ class FAMEDescriptors:
 
     def compute_fame_descriptors(
         self, in_file: str, out_folder: str, has_soms: bool
-    ) -> Tuple[np.ndarray, list[str], np.ndarray, Optional[np.ndarray], np.ndarray]:
+    ) -> tuple[np.ndarray, list[str], np.ndarray, np.ndarray | None, np.ndarray]:
         """Compute FAME descriptors for a given molecule.
 
         Args:
@@ -290,7 +289,7 @@ class FAMEDescriptors:
 
     def _get_output_file_paths(
         self, in_file_path: Path, out_folder_path: Path
-    ) -> Tuple[Path, Path]:
+    ) -> tuple[Path, Path]:
         """Generate output file paths for descriptors and not-calculated compounds."""
         out_not_calculated = (
             out_folder_path
@@ -307,16 +306,16 @@ class FAMEDescriptors:
         out_not_calculated: Path,
         out_descriptors: Path,
         has_soms: bool,
-    ) -> Tuple[np.ndarray, List[str], np.ndarray, Optional[np.ndarray], np.ndarray]:
+    ) -> tuple[np.ndarray, list[str], np.ndarray, np.ndarray | None, np.ndarray]:
         """Compute and save descriptors from molecules."""
         reader = Chem.FileSDFMoleculeReader(in_file)
         mol = Chem.BasicMolecule()
 
-        mol_num_ids: List[int] = []
-        mol_ids: List[str] = []
-        atom_ids: List[int] = []
-        som_labels: List[int] = []
-        descriptors_lst: List[List[float]] = []
+        mol_num_ids: list[int] = []
+        mol_ids: list[str] = []
+        atom_ids: list[int] = []
+        som_labels: list[int] = []
+        descriptors_lst: list[list[float]] = []
 
         with (
             open(out_not_calculated, "w", encoding="UTF-8") as f_not_calc,
@@ -385,7 +384,7 @@ class FAMEDescriptors:
 
     def _read_precomputed_descriptors(
         self, out_descriptors: Path, has_soms: bool
-    ) -> Tuple[np.ndarray, List[str], np.ndarray, Optional[np.ndarray], np.ndarray]:
+    ) -> tuple[np.ndarray, list[str], np.ndarray, np.ndarray | None, np.ndarray]:
         """Read previously computed descriptors from a file."""
         print(f"Reading pre-calculated descriptors from {out_descriptors}")
 

--- a/scripts/cv_hp_search.py
+++ b/scripts/cv_hp_search.py
@@ -18,7 +18,6 @@ import sys
 from collections import Counter
 from datetime import datetime
 from statistics import mean, stdev
-from typing import Dict, List
 
 import numpy as np
 from sklearn.ensemble import RandomForestClassifier
@@ -129,7 +128,7 @@ def main():
             file.write(f"{param}: {value}\n")
     print(f"Best hyperparameters saved to {best_params_file}")
 
-    metrics: Dict[str, List[float]] = {
+    metrics: dict[str, list[float]] = {
         "AUROC": [],
         "Average precision": [],
         "F1": [],

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -15,7 +15,6 @@ import os
 import sys
 from datetime import datetime
 from statistics import mean, stdev
-from typing import Dict, List
 
 import numpy as np
 from joblib import load
@@ -109,7 +108,7 @@ def main():
     y_prob = clf.predict_proba(descriptors)[:, 1]
     y_pred = (y_prob > args.threshold).astype(int)
 
-    metrics: Dict[str, List[float]] = {
+    metrics: dict[str, list[float]] = {
         "AUROC": [],
         "Average precision": [],
         "F1": [],


### PR DESCRIPTION
The types for Python primitives imported from "typing" are deprecated
in newer versions of Python. Also it is suggested to use "Type | None`
instead of "Optional[T]".

I also made a few type hints more concrete.