### PR TITLE
Do not globally suppress warnings in compute_descriptors

### DIFF
--- a/fame3r/compute_descriptors.py
+++ b/fame3r/compute_descriptors.py
@@ -1,18 +1,14 @@
 """Module for computing FAME descriptors for a given molecule."""
 
 import ast
+import csv
 import os
 import sys
-import warnings
 from pathlib import Path
 from typing import List, Optional, Tuple
 
 import numpy as np
-import pandas as pd
 from CDPL import Chem, ForceField, MolProp
-
-# Suppress pandas performance warning
-warnings.simplefilter(action="ignore", category=pd.errors.PerformanceWarning)
 
 SYBYL_ATOM_TYPE_IDX_CDPKIT = [
     1,


### PR DESCRIPTION
It is not considered good practice to modify global rules like
configuring warning messages in library code. Instead, users should do
this themselves when they need to.